### PR TITLE
Simplify "make check" rule

### DIFF
--- a/src/test/sql/regress/Makefile
+++ b/src/test/sql/regress/Makefile
@@ -1,33 +1,11 @@
-POSTGIS_SCRIPT_DIR ?=/usr/share/postgresql/11/contrib/postgis-2.5
 
-check: loader 00-regress
-	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl --spatial_ref_sys --topology $(RUNTESTFLAGS) resolve_overlap_and_gap
+check: loader #00-regress
+	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl -v --spatial_ref_sys --extension --topology $(RUNTESTFLAGS) resolve_overlap_and_gap
 
 loader:
-#	find / -name shp2pgsql 2>/dev/null # debug 
-#	ls # debug
-	
-#	export PATH=$(PATH):`pg_config --bindir`; 
-	export PATH=$(PATH):/usr/bin
-	
-	which shp2pgsql pgsql2shp > /dev/null || \
-    { echo "shp2pgsql and pgsql2shp must be in your PATH" && exit 1; }; \
 	mkdir -p ../loader; \
-	ln -fs `which shp2pgsql` ../loader; \
-	ln -fs `which pgsql2shp` ../loader
+	touch ../loader/shp2pgsql
+	chmod +x ../loader/shp2pgsql
+	touch ../loader/pgsql2shp
+	chmod +x ../loader/pgsql2shp
 
-00-regress:
-	find /usr/share/postgresql -name postgis.sql # debug 
-	find /usr/share/postgresql -name shp2pgsql # debug 
-	ls $(POSTGIS_SCRIPT_DIR) # debug
-	
-	@test -f $(POSTGIS_SCRIPT_DIR)/postgis.sql || \
-    { echo "No postgis.sql file found in $(POSTGIS_SCRIPT_DIR)," \
-           "please tweak \$$POSTGIS_SCRIPT_DIR" && exit 1; }
-	@test -f $(POSTGIS_SCRIPT_DIR)/topology.sql || \
-    { echo "No topology.sql file found in $(POSTGIS_SCRIPT_DIR)," \
-           "please tweak \$$POSTGIS_SCRIPT_DIR" && exit 1; }
-	test -e 00-regress-install/share/contrib/postgis || { \
-	mkdir -p 00-regress-install/share/contrib; \
-	ln -fs $(POSTGIS_SCRIPT_DIR) 00-regress-install/share/contrib/postgis; \
-  }

--- a/src/test/sql/regress/Makefile
+++ b/src/test/sql/regress/Makefile
@@ -1,6 +1,6 @@
 
 check: loader #00-regress
-	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl -v --spatial_ref_sys --extension --topology $(RUNTESTFLAGS) resolve_overlap_and_gap
+	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl -v --spatial_ref_sys --extension --topology $(RUNTESTFLAGS) ./resolve_overlap_and_gap
 
 loader:
 	mkdir -p ../loader; \


### PR DESCRIPTION
- Do not require shp2pgsql and pgsql2shp (not needed)
- Use EXTENSION mechanism for loading PostGIS