### PR TITLE
Update README about running tests

### DIFF
--- a/src/test/sql/README
+++ b/src/test/sql/README
@@ -5,19 +5,10 @@ Run from src/test/sql directory
 mkdir loader
 ln -s /usr/local/bin/shp2pgsql loader
 ln -s /usr/local/bin/pgsql2shp loader
-mkdir -p regress/00-regress-install/share/contrib
-ln -s /usr/local/Cellar/postgis/3.0.0/share/postgis regress/00-regress-install/share/contrib/
 
-You may also need to set 
-export POSTGIS_SCRIPT_DIR=/usr/local/Cellar/postgis/2.2.1/share/postgis/
- 
-This can probably be done in better way, please let me now.
+Then you can run a simple test in the regress directory:
 
-Then you can run a simple test in the regress directory
-
-By the way ypu update the README file for run_test.pl in the file I coppiedform 
-
-./run_test.pl --verbose --spatial_ref_sys --topology resolve_overlap_and_gap
+./run_test.pl --extension --verbose --topology resolve_overlap_and_gap
 
 
 

--- a/src/test/sql/regress/Makefile
+++ b/src/test/sql/regress/Makefile
@@ -1,6 +1,6 @@
 
 check: loader #00-regress
-	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl -v --spatial_ref_sys --extension --topology $(RUNTESTFLAGS) ./resolve_overlap_and_gap
+	POSTGIS_REGRESS_DB=nibio_reg ./run_test.pl -v --extension --topology $(RUNTESTFLAGS) ./resolve_overlap_and_gap
 
 loader:
 	mkdir -p ../loader; \


### PR DESCRIPTION
And drop use of --spatial-ref-sys, which is not needed anymore
now that we use --extension (already loads spatial-ref-sys)

NOTE: the upstream run_test.pl does NOT have --spatial-ref-sys
      so if this is a local custom switch, we may consider
      dropping it back, and resort to upstream run_test.pl