### PR TITLE
Add auto-help support in top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-all:
-	@echo "Try make check"
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@grep -E '^[$$() a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+    sed 's/$$(IMAGES)/$(IMAGES)/' | \
+    sed 's/$$(IMAGES_PUSH)/$(IMAGES_PUSH)/' | \
+    awk \
+      'BEGIN {FS = ":.*?## "}; \
+      { printf "\033[36m%-30s\033[0m%s%s\n", $$1, "\n ", $$2 }'
 
-check:
+check: ## Run regression tests
 	$(MAKE) -C src/test/sql/regress/ check


### PR DESCRIPTION
Run `make` with no args to see which targets are available
and documentation for each.